### PR TITLE
Move IP address to SysInfo

### DIFF
--- a/SysInfo.proto
+++ b/SysInfo.proto
@@ -84,7 +84,13 @@ message Block {
   string protocolDate = 9
       [ (brewblox.field).readonly = true, (nanopb).max_size = 12 ];
 
-  Command command = 10;
-  repeated Trace trace = 11
+  uint32 ip = 10 [
+    (brewblox.field).readonly = true,
+    (brewblox.field).ipv4address = true,
+    (nanopb).int_size = IS_32
+  ];
+
+  Command command = 100;
+  repeated Trace trace = 101
       [ (brewblox.field).readonly = true, (nanopb).max_count = 10 ];
 }

--- a/SysInfo.proto
+++ b/SysInfo.proto
@@ -84,10 +84,10 @@ message Block {
   string protocolDate = 9
       [ (brewblox.field).readonly = true, (nanopb).max_size = 12 ];
 
-  uint32 ip = 10 [
+  string ip = 10 [
     (brewblox.field).readonly = true,
-    (brewblox.field).ipv4address = true,
-    (nanopb).int_size = IS_32
+    (nanopb).max_size = 16,
+    (nanopb).fixed_length = true
   ];
 
   Command command = 100;

--- a/SysInfo.proto
+++ b/SysInfo.proto
@@ -84,10 +84,10 @@ message Block {
   string protocolDate = 9
       [ (brewblox.field).readonly = true, (nanopb).max_size = 12 ];
 
-  string ip = 10 [
+  uint32 ip = 10 [
     (brewblox.field).readonly = true,
-    (nanopb).max_size = 16,
-    (nanopb).fixed_length = true
+    (brewblox.field).ipv4address = true,
+    (nanopb).int_size = IS_32
   ];
 
   Command command = 100;

--- a/WiFiSettings.proto
+++ b/WiFiSettings.proto
@@ -34,9 +34,4 @@ message Block {
     (brewblox.field).logged = true,
     (nanopb).int_size = IS_8
   ];
-  string ip = 6 [
-    (brewblox.field).readonly = true,
-    (nanopb).max_size = 16,
-    (nanopb).fixed_length = true
-  ];
 }

--- a/brewblox.proto
+++ b/brewblox.proto
@@ -92,7 +92,6 @@ message FieldOpts {
   bool ignored = 9;
   bool bitfield = 10;
   bool datetime = 11;
-  bool ipv4address = 12;
 }
 
 extend google.protobuf.FieldOptions {

--- a/brewblox.proto
+++ b/brewblox.proto
@@ -92,6 +92,7 @@ message FieldOpts {
   bool ignored = 9;
   bool bitfield = 10;
   bool datetime = 11;
+  bool ipv4address = 12;
 }
 
 extend google.protobuf.FieldOptions {


### PR DESCRIPTION
IP address is returned as host-order uint32, and marked with brewblox.field.ipv4address.
