### PR TITLE
TempControlSurface block

### DIFF
--- a/proto/ControlSurface.proto
+++ b/proto/ControlSurface.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+import "brewblox.proto";
+import "nanopb.proto";
+
+package blox.ControlSurface;
+
+message Block {
+  option (brewblox.msg).objtype = ControlSurface;
+  option (brewblox.msg).impl = EnablerInterface;
+
+  bool enabled = 1 [ (brewblox.field).logged = true ];
+
+  string sessionName = 2;
+  uint32 sessionStart = 3
+      [ (brewblox.field).datetime = true, (nanopb).int_size = IS_32 ];
+  uint32 sessionEnd = 4
+      [ (brewblox.field).datetime = true, (nanopb).int_size = IS_32 ];
+
+  uint32 setpoint = 10 [
+    (brewblox.field).objtype = SetpointSensorPairInterface,
+    (nanopb).int_size = IS_16
+  ];
+
+  uint32 profile = 11
+      [ (brewblox.field).objtype = SetpointProfile, (nanopb).int_size = IS_16 ];
+
+  uint32 sequence = 12
+      [ (brewblox.field).objtype = Sequence, (nanopb).int_size = IS_16 ];
+}

--- a/proto/TempControlSurface.proto
+++ b/proto/TempControlSurface.proto
@@ -3,10 +3,10 @@ syntax = "proto3";
 import "brewblox.proto";
 import "nanopb.proto";
 
-package blox.ControlSurface;
+package blox.TempControlSurface;
 
 message Block {
-  option (brewblox.msg).objtype = ControlSurface;
+  option (brewblox.msg).objtype = TempControlSurface;
   option (brewblox.msg).impl = EnablerInterface;
 
   bool enabled = 1 [ (brewblox.field).logged = true ];

--- a/proto/brewblox.proto
+++ b/proto/brewblox.proto
@@ -69,6 +69,7 @@ enum BlockType {
   OneWireGpioModule = 325;
   Sequence = 326;
   TempSensorExternal = 328;
+  ControlSurface = 329;
 }
 
 message MessageOpts {

--- a/proto/brewblox.proto
+++ b/proto/brewblox.proto
@@ -69,7 +69,7 @@ enum BlockType {
   OneWireGpioModule = 325;
   Sequence = 326;
   TempSensorExternal = 328;
-  ControlSurface = 329;
+  TempControlSurface = 329;
 }
 
 message MessageOpts {


### PR DESCRIPTION
# TempControlSurface block

A significant shortcoming of Brewblox is that it has a significant barrier to entry, and very little abstraction for end users.
All settings are accessible and present all the time.

The flexible configuration also complicates integration with third-party services that generate control settings.

In this case, both users and external services would benefit from having a clearly defined entry point that provides a clear and unambiguous view of the settings required to control the system at runtime.

We only have a basic idea of what the requirements would be for recipe / batch integration services that interact with external applications like Brewfather.
Any solution implemented at this time must make an effort to be universally useful and applicable.

## Scenarios

Three separate scenarios are relevant here:

- The system has a single user, who is thoroughly familiar with the system.
- The system has multiple users. One or more is familiar with the system, the others are not, and require a turnkey solution.
- An external service translates recipe or process data into temperature control over time.

We can use a role-based approach to model these scenarios.

The **sysadmin** installed and configured the system.
They're familiar with the control theory and associated configuration options,
and have tuned the system until it performed as desired.
They know everything about temperature control of water-like liquids, and very little about brewing.

The **brewer**, on the other hand, is unfamiliar with temperature control theory, but is a domain expert when it comes to making beer.

Even if a user is intimately familiar with the system, they would rather not think about setup-time configuration while brewing.
We can consider the expert user from the first scenario to swap roles from *sysadmin* to *brewer* during brew days.

In the second scenario, the *sysadmin* and *brewer* roles are filled by separate people,
and we should assume that the *brewer* can't call on the *sysadmin* during brew days.

In the third scenario, a recipe service lives in the domain of the *brewer* role.
A recipe will merely dictate volume and temperature, and leave it up to the system to achieve them.

For typical setups, the controls required by the *brewer* role are:

- Enable / disable temperature control
- Set a constant Setpoint setting
- Set gradual / conditional Setpoint setting changes

A reduction is configuration flexibility is undesirable.
All pre-existing configuration options should remain accessible.

For humans, this means we want to hide all configuration apart from the settings listed above to reduce cognitive load.
Requiring authentication / authorization checks to access the hidden data is outside the scope of this feature.

For services, cognitive load is less important than the ability to select the relevant blocks with a minimum of assumptions or conditionals.

## Level of abstraction

All required settings are already present and accessible in Brewblox, but we need to separate settings that are relevant to the *brewer* from everything that's only used by the *sysadmin*.

This can be done by adding an interface that is strictly limited to concepts relevant to the *brewer* role.
Here, relevant concepts are physical, not logical. "Fermentation tank 2" is relevant, "PID control" is not.

The exposed level of detail should reflect this. Regardless of control chain implementation, this new interface should provide the *brewer* temperature controls (listed above) for the physical concept.

Examples of practical use cases are:

- Fridge 3 is empty. Disable temperature control.
- Heat the mash to 60\*C. Keep it steady for 20 minutes, then gradually increase temperature to 70\*C.
- The cold crash in tank A is due in two days.

## Implementation

The proposed new API interface does not expose any new settings,
but groups pre-existing settings to clearly state intent and relevance.

By existing, the new interface communicates two new pieces of information:

- Which conceptual resources are available? (X number of kettles, Y number of fermentation tanks, etc.)
- Which blocks and settings are used to control any given resource?

The block can also be used to store metadata on the conceptual resources:

- How is the resource used? (active session name)
- Between what dates is the resource used?

This information is persistent (it can't be trivially derived),
and is relevant to both human users and external services.
It references no information outside the controller scope
but is tightly coupled to blocks on the controller.

For this reason, the interface is best implemented on the controller itself.

The stored information is metadata not directly relevant to active temperature control chains.
A new block is a more suitable implementation than us adding fields to existing blocks.

### Single vs multiple blocks

There are two approaches to storing this non-control metadata: a single system block with a list of resources, or multiple userspace blocks that all describe a single resource.

The userspace block solution is preferred, for the following reasons:

- Blocks must be written separately. Patch commands are shallow, and would have to write the entire list every time they update a single resource.
- The block is linked to the control chains defined on the Spark, and does not describe a property of the Spark itself.
- A list-based solution would require us to introduce unique IDs per resource, in order to safely express CRUD operations from different sources.

### Block name

The proposed block name is **TempControlSurface**.

- It describes a view (or control surface) consisting of a very specific subset of existing settings.
- We do not exclude the future existence of other blocks with the same stated goals, but for something other than temperatures.
- These future blocks are likely to have a significantly different data model and implementation. It is unlikely the new functionality can be added to this block.

Secondary options are *Resource* or *TempControlResource*.

### Block fields

To implement the desired functionality, the following fields would be relevant:

- `enabled: boolean`: enable or disable all temperature control for the resource.
- `sessionName: string`: metadata for humans.
- `sessionStart: datetime | null`: metadata for humans.
- `sessionEnd: datetime | null`: metadata for humans.
- `setpoint: Link<SetpointSensorPair>`: the primary entrypoint for *brewer* control.
- `profile: Link<SetpointProfile> | null`: if a setpoint profile is required, this block should be used.
- `sequence: Link<Sequence> | null`: if a sequence is required, this block should be used.

`enabled` can disable temperature control, but for overall temperature control to be enabled, all blocks in the chain must be enabled.

`sessionName`, `sessionStart`, and `sessionEnd` are not actively used in temperature control, but give feedback to end users.
This can serve as a soft claim for the resource.

`profile` and `sequence` are linked explicitly to clearly state intent even when disabled or inactive.
They are tools that can be used to drive the setpoint, but they are optional, and the control chain will function without them.

If they are not defined, but required by an external service, the service may create new blocks, and add the links to the control surface.

## UI integration

The *TempControlSurface* block can be used for easy enumeration of runtime-relevant data in the UI.
There are multiple use cases for this:

- A one-stop-shop dashboard widget that replaces the *Setpoint* and *Setpoint Profile* widgets generated by various Quickstart wizards.
- A third view on the Spark service page, where all control surfaces on the controller are listed for easy access.
- A mobile-friendly home page. This would list all control surfaces of all listed Spark services.
- A Builder part that can be integrated well with the existing Glycol tank and Kettle parts.

## Temp Control Assistant and PID-based entrypoints

There is some overlap between the *TempControlSurface* block and the existing *Temp Control Assistant* widget, but there are also some critical differences.

*TempControlSurface* is strictly limited to runtime control.
Changes to PID settings are explicitly excluded.

*Temp Control Assistant* is useful for runtime control, but a significant part of its feature set is related to management of PID settings.
A single *Temp Control Assistant* may switch between multiple control modes (eg. Fridge Mode and Beer Mode) where the PIDs are unlinked from one setpoint, and then attached to another.

In this scenario, we would expect to have a *TempControlSurface* block for both the Fridge setpoint and the Beer setpoint.

## Discussion

If *TempControlSurface* is enabled, and *SetpointSensorPair* is disabled, is the *SetpointSensorPair* enabled, disabled, or inactive?

To facilitate switching between control modes, we could define a new field in *TempControlSurface*: `alternativeSetpoints`.

To implement the interaction between `enabled` fields in various blocks,
we may want to build a more formal claiming mechanism for driven blocks and IO channels.

Especially with switchable control modes, control surfaces may be inactive (there is no PID attached to the setpoint, or any block in the chain is disabled).
We could formalize this behavior by implementing some `IndirectlyInactive` interface that can be propagated up and down a chain.
This would require protection against circular references such as those present in setups with dynamic setpoints.
